### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ We call this packaged container a _machine_.
 ### Schema
 The data that your algorithm evaluates is called its _inputs_, the data your algorithm produces is called its _outputs_.
 Both input and outputs must have well defined data type definitions called a _schema_.
-The McCoy Platform uses an YAML-Schema and some custom extensions to describe the Machine inputs and outputs as well as 
-some display information. 
+The McCoy Platform uses [JSON-Schema](http://json-schema.org) and some custom extensions to describe the Machine inputs and outputs as well as some display information, either JSON or YAML formatted schemas are accepted.
 
 ### Accounts, Organizations, and Sharing
 If you are the first person from your organization to use the McCoy Platform, you can create an account and organization

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We call this packaged container a _machine_.
 ### Schema
 The data that your algorithm evaluates is called its _inputs_, the data your algorithm produces is called its _outputs_.
 Both input and outputs must have well defined data type definitions called a _schema_.
-The McCoy Platform uses an Json-Schema and some custom extensions to describe the Machine inputs and outputs as well as 
+The McCoy Platform uses an YAML-Schema and some custom extensions to describe the Machine inputs and outputs as well as 
 some display information. 
 
 ### Accounts, Organizations, and Sharing


### PR DESCRIPTION
the schema inside the images for the labels is clearly YAML (json would have all the lovely brackets without any of the fun whitespace)

```
LABEL mccoy.schema_in "\
title: 'sans-sang-tool-in-ct'\n\
type: 'object'\n\
properties:\n\
  test-dicom:\n\
    type: array\n\
    items:\n\
      type: string\n\
      format: base64\n\
      title: test.dcm\n\
    _mime-type: application/dcm\n\
    _control: directory"
```